### PR TITLE
Assignhooks patch more modules

### DIFF
--- a/alt_instrument.py
+++ b/alt_instrument.py
@@ -1,0 +1,44 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2021 patgolez10, sinavir
+"""asignhooks patch to instrument only modules from specific paths"""
+
+import os.path
+
+import assignhooks
+
+origin_import = __import__
+
+path = []
+
+
+def custom_import(name, *args, **kwargs):
+    module = origin_import(name, *args, **kwargs)
+    if not hasattr(module, "__file__") or not _is_in_path(module.__file__):
+        return module
+    try:
+        assignhooks.patch.patch_module(
+            module, trans=assignhooks.transformer.AssignTransformer
+        )
+    except Exception as e:
+        print(e)
+        return module
+    return module
+
+
+def _is_in_path(p):
+    """
+    test if one membre of `path` is a prefix of `p`
+    """
+    p = os.path.normpath(p)
+    for i in path:
+        if i == os.path.commonpath([i, p]):
+            return True
+    return False
+
+
+def start():
+    __builtins__.update(**dict(__import__=custom_import))
+
+
+def stop():
+    __builtins__.update(**dict(__import__=origin_import))

--- a/carotte.py
+++ b/carotte.py
@@ -37,12 +37,15 @@ if sys.version_info < MIN_PYTHON:
     sys.exit(1)
 
 
-def process(module_file: str, output_filename: str = None) -> None:
+def process(module_file: str, output_filename: str = None, assignhooks_path: str = None) -> None:
     '''Process a carotte.py input python file and build its netlist'''
     module_dir, module_name = os.path.split(os.path.abspath(module_file))
     sys.path.append(module_dir)
     if assignhooks is not None:
-        alt_instrument.path.append(module_dir)
+        if assignhooks_path is None:
+            alt_instrument.path.append(module_dir)
+        else:
+            alt_instrument.path = [ os.path.abspath(i) for i in assignhooks_path.split(':')]
     module_name = re.sub("\\.py$", "", module_name)
     if assignhooks is not None:
         alt_instrument.start()
@@ -53,7 +56,6 @@ def process(module_file: str, output_filename: str = None) -> None:
         sys.exit(1)
     if assignhooks is not None:
         alt_instrument.stop()
-        assignhooks.patch_module(module)
     lib_carotte.reset()
     module.main() # type: ignore
 
@@ -69,8 +71,9 @@ def main() -> None:
     parser = argparse.ArgumentParser(description='carotte.py DSL')
     parser.add_argument("module_file", nargs=1)
     parser.add_argument('-o', '--output-file', help='Netlist output file')
+    parser.add_argument('-p', '--assignhooks-path', help='Python files from these folder will have nice variable names if `assignhooks` is present. Takes a colon separated list of paths')
     args = parser.parse_args()
-    process(args.module_file[0], args.output_file)
+    process(args.module_file[0], args.output_file, args.assignhooks_path)
 
 if __name__ == "__main__":
     main()

--- a/carotte.py
+++ b/carotte.py
@@ -37,16 +37,21 @@ if sys.version_info < MIN_PYTHON:
     sys.exit(1)
 
 
-def process(module_file: str, output_filename: str = None, assignhooks_path: str = None) -> None:
+def process(module_file: str, output_filename: str = None, assignhooks_path: str = None, module_name: str = None, python_path: str = None) -> None:
     '''Process a carotte.py input python file and build its netlist'''
-    module_dir, module_name = os.path.split(os.path.abspath(module_file))
-    sys.path.append(module_dir)
+    module_dir, filename = os.path.split(os.path.abspath(module_file))
+    if python_path is None:
+        sys.path.append(module_dir)
+    else:
+        for i in python_path.split(':'):
+            sys.path.append(os.path.abspath(i))
     if assignhooks is not None:
         if assignhooks_path is None:
             alt_instrument.path.append(module_dir)
         else:
             alt_instrument.path = [ os.path.abspath(i) for i in assignhooks_path.split(':')]
-    module_name = re.sub("\\.py$", "", module_name)
+    if module_name is None:
+        module_name = re.sub("\\.py$", "", filename)
     if assignhooks is not None:
         alt_instrument.start()
     try:
@@ -72,8 +77,10 @@ def main() -> None:
     parser.add_argument("module_file", nargs=1)
     parser.add_argument('-o', '--output-file', help='Netlist output file')
     parser.add_argument('-p', '--assignhooks-path', help='Python files from these folder will have nice variable names if `assignhooks` is present. Takes a colon separated list of paths')
+    parser.add_argument('-m', '--module-name', help="Carotte.py module entrypoint. Usually, you don't have to specify it unless you specify --python-path option. Default: module_file filename without `.py`")
+    parser.add_argument('-y', '--python-path', help="Additionnal paths python will look to while importing modules (the entrypoint is a module). Default: directory containing module_file")
     args = parser.parse_args()
-    process(args.module_file[0], args.output_file, args.assignhooks_path)
+    process(args.module_file[0], args.output_file, args.assignhooks_path, args.module_name, args.python_path)
 
 if __name__ == "__main__":
     main()

--- a/carotte.py
+++ b/carotte.py
@@ -24,6 +24,7 @@ try:
     #assignhooks.transformer.debug = True
     import alt_transformer
     assignhooks.transformer.AssignTransformer.visit_Assign = alt_transformer.visit_Assign
+    import alt_instrument
 except ModuleNotFoundError:
     print("Warning: Install module 'assignhooks' for better variable names", file=sys.stderr)
     assignhooks = None
@@ -40,13 +41,18 @@ def process(module_file: str, output_filename: str = None) -> None:
     '''Process a carotte.py input python file and build its netlist'''
     module_dir, module_name = os.path.split(os.path.abspath(module_file))
     sys.path.append(module_dir)
+    if assignhooks is not None:
+        alt_instrument.path.append(module_dir)
     module_name = re.sub("\\.py$", "", module_name)
+    if assignhooks is not None:
+        alt_instrument.start()
     try:
         module = __import__(module_name)
     except ModuleNotFoundError:
         print(f"Could not load file '{module_file}'", file=sys.stderr)
         sys.exit(1)
     if assignhooks is not None:
+        alt_instrument.stop()
         assignhooks.patch_module(module)
     lib_carotte.reset()
     module.main() # type: ignore


### PR DESCRIPTION
Cette PR permet de faire en sorte que la plupart des fichiers source soient patchés par `assignhooks`

L'idée est de reprendre le code d'instrumentation de `assignhooks` mais en ne patchant que les modules qui sont dans certaines branches du système de fichier (celles spécifiées par `alt_instrument.path`).

Dépend de https://github.com/TWal/carotte.py/pull/5