### PR TITLE
Allow improved syntax of Concat with Defer

### DIFF
--- a/lib_carotte.py
+++ b/lib_carotte.py
@@ -176,7 +176,26 @@ class Defer:
     def name(self) -> str:
         '''We want to compute the variable name lazily'''
         return self.get_val().name
-    
+    def __and__(self, rhs: 'Variable') -> 'Variable':
+        return And(self, rhs)
+    def __or__(self, rhs: 'Variable') -> 'Variable':
+        return Or(self, rhs)
+    def __xor__(self, rhs: 'Variable') -> 'Variable':
+        return Xor(self, rhs)
+    def __invert__(self) -> 'Variable':
+        return Not(self)
+    def __len__(self) -> int:
+        return self.bus_size    
+    def __getitem__(self, index: typing.Union[int, slice]) -> 'Variable':
+        if isinstance(index, slice):
+            if (index.step is not None) and (index.step != 1):
+                raise TypeError(f"Slices must use a step of '1' (have {index.step})")
+            start = 0 if index.start is None else index.start
+            stop = self.bus_size if index.stop is None else index.stop
+            return Slice(start, stop, self)
+        if isinstance(index, int):
+            return Select(index, self)
+        raise TypeError(f"Invalid getitem, index: {index} is neither a slice or an integer")
     def __add__(self, rhs: 'VariableOrDefer') -> 'Variable':
         return Concat(self, rhs)
 

--- a/lib_carotte.py
+++ b/lib_carotte.py
@@ -153,7 +153,7 @@ class Variable(typing.Sequence['Variable']):
         if isinstance(index, int):
             return Select(index, self)
         raise TypeError(f"Invalid getitem, index: {index} is neither a slice or an integer")
-    def __add__(self, rhs: 'Variable') -> 'Variable':
+    def __add__(self, rhs: 'VariableOrDefer') -> 'Variable':
         return Concat(self, rhs)
 
 class Defer:
@@ -176,6 +176,9 @@ class Defer:
     def name(self) -> str:
         '''We want to compute the variable name lazily'''
         return self.get_val().name
+    
+    def __add__(self, rhs: 'VariableOrDefer') -> 'Variable':
+        return Concat(self, rhs)
 
 VariableOrDefer = typing.Union[Variable, Defer]
 


### PR DESCRIPTION
Proposed a quick fix for Issue #8. It seems to work since Python isn’t too strict about types, but I’m not convinced the types are entirely accurate.